### PR TITLE
[FIX] hw_escpos: wrong number of argument in write function

### DIFF
--- a/addons/hw_escpos/escpos/printer.py
+++ b/addons/hw_escpos/escpos/printer.py
@@ -83,7 +83,7 @@ class Usb(Escpos):
 
     def _raw(self, msg):
         """ Print any command sent in raw format """
-        if len(msg) != self.device.write(self.out_ep, msg, self.interface, timeout=5000):
+        if len(msg) != self.device.write(self.out_ep, msg, timeout=5000):
             self.device.write(self.out_ep, self.errorText, self.interface)
             raise TicketNotPrinted()
     


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
