### PR TITLE
9.0 fix pos fixed tax calculation

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1334,8 +1334,8 @@ exports.Orderline = Backbone.Model.extend({
     },
     _compute_all: function(tax, base_amount, quantity) {
         if (tax.amount_type === 'fixed') {
-            var sign_base_amount = base_amount >= 0 ? 1 : -1;
-            return (Math.abs(tax.amount) * sign_base_amount) * quantity;
+            var sign_base_amount = Math.sign(base_amount) || 1;
+            return tax.amount * sign_base_amount * Math.abs(quantity);
         }
         if ((tax.amount_type === 'percent' && !tax.price_include) || (tax.amount_type === 'division' && tax.price_include)){
             return base_amount * tax.amount / 100;

--- a/addons/sale_timesheet/models/sale_timesheet.py
+++ b/addons/sale_timesheet/models/sale_timesheet.py
@@ -63,7 +63,12 @@ class AccountAnalyticLine(models.Model):
                     'product_id': sol.product_id.id,
                 })
                 result = self._get_timesheet_cost(result)
-
+            else:
+                result.update({
+                    'so_line': False,
+                    'product_id': False,
+                })
+                result = self._get_timesheet_cost(result)
         result = super(AccountAnalyticLine, self)._get_sale_order_line(vals=result)
         return result
 

--- a/addons/sale_timesheet/models/sale_timesheet.py
+++ b/addons/sale_timesheet/models/sale_timesheet.py
@@ -46,6 +46,8 @@ class AccountAnalyticLine(models.Model):
         if self.is_timesheet:
             if result.get('so_line'):
                 sol = self.env['sale.order.line'].browse([result['so_line']])
+            elif result.get('account_id'):
+                sol = False
             else:
                 sol = self.so_line
             if not sol and self.account_id:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When returning products with a fixed tax, the fixed tax is added with the wrong sign, due to a double negative sign. Hence, the prices of positive and negative amounts are not symmetrical.
The amount differed from what can be observed in sales

This is a port of [this](https://github.com/odoo/odoo/pull/34548) PR in Odoo v11  to v9.

Current behavior before PR:

The prices of positive and negative amounts **are not** symmetrical

Desired behavior after PR is merged:
The prices of positive and negative amounts **are** symmetrical



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
