### PR TITLE
[FIX] purchase: patch _check to take cancel moves into account

### DIFF
--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -799,7 +799,7 @@ class ProcurementOrder(models.Model):
         if procurement.purchase_line_id:
             if not procurement.move_ids:
                 return False
-            return all(move.state == 'done' for move in procurement.move_ids)
+            return all(move.state in ('cancel', 'done') for move in procurement.move_ids)
         return super(ProcurementOrder, self)._check(procurement)
 
     @api.v8


### PR DESCRIPTION
**BEFORE**: procurement remain running if some move line in linked PO are cancelled

**FIX**: procurement is now considered done if linked moves are done OR cancelled.